### PR TITLE
Bug Fix - Table Output Argument

### DIFF
--- a/Main.m
+++ b/Main.m
@@ -1,8 +1,8 @@
-function [Aircraft, Mission_History] = Main(InputAircraft, ProfileFxn)
+function [Aircraft, MissionHistory] = Main(InputAircraft, ProfileFxn)
 %
-% [Aircraft, Mission_History] = Main(InputAircraft, ProfileFxn)
+% [Aircraft, MissionHistory] = Main(InputAircraft, ProfileFxn)
 % written by Paul Mokotoff, prmoko@umich.edu
-% last updated: 24 apr 2024
+% last updated: 06 may 2024
 %
 % NOTE: please see README.m in the root directory for all
 %       disclaimers and how to run FAST.
@@ -11,25 +11,30 @@ function [Aircraft, Mission_History] = Main(InputAircraft, ProfileFxn)
 % configuration by flying a user-requested mission profile.
 %
 % INPUTS:
-%     InputAircraft - function handle for the aircraft to be sized or an 
-%                     already existing aircraft struct. Since all aircraft
-%                     are in the "AircraftSpecsPkg" folder, the function
-%                     handle must be provided as
-%                     "AircraftSpecsPkg.MyAircraft", where "MyAircraft" is
-%                     the .m file in the "AircraftSpecsPkg" folder
-%                     describing the aircraft's configuration.
-%                     size/type/units: 1-by-1 / struct or function handle / []
+%     InputAircraft  - function handle for the aircraft to be sized or an 
+%                      already existing aircraft struct. Since all aircraft
+%                      are in the "AircraftSpecsPkg" folder, the function
+%                      handle must be provided as
+%                      "AircraftSpecsPkg.MyAircraft", where "MyAircraft" is
+%                      the .m file in the "AircraftSpecsPkg" folder
+%                      describing the aircraft's configuration.
+%                      size/type/units: 1-by-1 / struct or function handle / []
 %
-%     ProfileFxn    - function handle for the mission profile to be flown.
-%                     These typically reside in the "MissionProfilesPkg"
-%                     folder.
-%                     size/type/units: 1-by-1 / function handle / []
+%     ProfileFxn     - function handle for the mission profile to be flown.
+%                      These typically reside in the "MissionProfilesPkg"
+%                      folder.
+%                      size/type/units: 1-by-1 / function handle / []
 %
 % OUTPUTS:
-%     Aircraft      - a structure containing information about the aircraft
-%                     after it has been sized and the mission profile that
-%                     it flew during the analysis process.
-%                     size/type/units: 1-by-1 / struct / []
+%     Aircraft       - a structure containing information about the
+%                      aircraft after it has been sized and the mission
+%                      profile that it flew during the analysis process.
+%                      size/type/units: 1-by-1 / struct / []
+%
+%     MissionHistory - a (possibly empty) table with the mission history
+%                      after the aircraft flies the prescribed mission
+%                      profile.
+%                      size/type/units: 1-by-1 or 0-by-0 / table / []
 %
 
 
@@ -56,8 +61,8 @@ if (isnan(Aircraft.Settings.Analysis.Type))
     
 end
 
-% use regressions/projections to obtain more knowledge about the aircraft
-if Aircraft.Settings.Analysis.Type > 0
+% if on-design, use regressions/projections to obtain more knowledge about the aircraft
+if (Aircraft.Settings.Analysis.Type > 0)
     Aircraft = DataStructPkg.SpecProcessing(Aircraft);
 end
 
@@ -84,13 +89,12 @@ switch nargin
         return;
     end
 end
+
 % call the respective mission profile function
 Aircraft = ProfileFxn(Aircraft);
 
 % process the mission profile
 Aircraft = MissionSegsPkg.ProcessProfile(Aircraft);
-
-
 
 
 %% AIRCRAFT ANALYSIS %%
@@ -103,7 +107,6 @@ Type = Aircraft.Settings.Analysis.Type;
 
 % maximum number of sizing iterations, done from the AircraftSpecsPkg file
 MaxIter = Aircraft.Settings.Analysis.MaxIter;
-
 
 % check if power optimization settings are available
 if (isfield(Aircraft, "PowerOpt") == 1)
@@ -122,13 +125,8 @@ end
 %% MISSION PROFILE PLOTTING %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% turn plotting on/off:
-%     0: plotting off
-%     1: plotting on
-PlotResult = Aircraft.Settings.Plotting;
-
-% plot the results, if desired
-if (PlotResult == 1)
+% plot the results, if desired (if 1, generate plots; if 0, no plotting)
+if (Aircraft.Settings.Plotting == 1)
     PlotPkg.PlotMission(Aircraft);
 end
 
@@ -141,14 +139,25 @@ Aircraft.Mission.ProfileFxn = ProfileFxn;
 %% MISSION HISTORY TABLE %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% make a table on/off:
-%     0: table off
-%     1: table on
-TableOpt = Aircraft.Settings.Table;
+% check if a second output argument exists
+if ((nargout > 1) && (Aircraft.Settings.Table == 0))
+    
+    % warn the user that an empty table is returned
+    warning("WARNING - Main: two output arguments were provided, but Aircraft.Settings.Table is 0. An empty table will be returned. Set Aircraft.Settings.Table to 1 for a table to be returned.");
+    
+end
 
-% plot the results, if desired
-if (TableOpt == 1)
-    Mission_History = MissionHistTable(Aircraft);
+% check if a table should be made
+if (Aircraft.Settings.Table == 1)
+    
+    % make the table
+    MissionHistory = MissionHistTable(Aircraft);
+    
+else
+    
+    % return an empty table
+    MissionHistory = table();
+    
 end
 
 % ----------------------------------------------------------


### PR DESCRIPTION
Fixed bug associated with Issue #17. The value within Aircraft.Settings.Table will remain the same and not get changed by FAST. If the user provides two output arguments but doesn't want a table, a warning is thrown to notify them about this.