### PR TITLE
Specific Excess Power and Descent Fixes

### DIFF
--- a/+MissionSegsPkg/EvalDescent.m
+++ b/+MissionSegsPkg/EvalDescent.m
@@ -3,7 +3,7 @@ function [Aircraft] = EvalDescent(Aircraft)
 % [Aircraft] = EvalDescent(Aircraft)
 % written by Paul Mokotoff, prmoko@umich.edu
 % patterned after code written by Gokcin Cinar in E-PASS
-% last updated: 07 mar 2024
+% last updated: 03 sep 2024
 %
 % Evaluate a descent segment by iterating over the rate of climb and
 % instantaneous acceleration at each control point in the mission.
@@ -255,6 +255,9 @@ while (iter < MaxIter)
     % compute the power available
     Aircraft = PropulsionPkg.PowerAvailable(Aircraft);
     
+    % get the power available
+    Pav = Aircraft.Mission.History.SI.Power.TV(SegBeg:SegEnd);
+    
     % ------------------------------------------------------
     
     %%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -278,11 +281,14 @@ while (iter < MaxIter)
     % compute power to overcome drag
     DV = D .* TAS;
     
-    % compute the specific excess power (idle engine while gliding)
-    Ps = -DV ./ (Mass .* g);
+    % compute the specific excess power
+    Ps = (Pav - DV) ./ (Mass .* g);
+    
+    % compute the gliding flight assumptions for now
+    MyPs = -DV ./ (Mass .* g);
 
     % compute time to fly (negate quotient for a dTime > 0)
-    dTime = diff(EnHt) ./ Ps(1:end-1);
+    dTime = diff(EnHt) ./ MyPs(1:end-1);
 
     % update the rate of climb
     dh_dt = [diff(Alt) ./ dTime; 0];


### PR DESCRIPTION
Previously, the specific excess power was less than zero during descent. This was because a gliding descent was assumed. However, the gliding descent is no longer assumed, and the specific excess power is always nonnegative. Rather than $$P_{s} = -\frac{DV}{W}$$ during descent, $$P_{s} = \frac{TV - DV}{W}$$ as it should be.

Additionally, the descent segment was updated to change how the flight performance is computed. If the user specifies a rate-of-descent, it is enforced. If the user doesn't specify a rate-of-descent, then the time to fly between control points is $$\Delta t = \left | \frac{\Delta h_{e}}{P_{s}} \right |$$, just as done in E-PASS.