### PR TITLE
Test Case Fixes

### DIFF
--- a/+PropulsionPkg/TestCreatePropArch.m
+++ b/+PropulsionPkg/TestCreatePropArch.m
@@ -2,7 +2,7 @@ function [Success] = TestCreatePropArch()
 %
 % [Success] = TestCreatePropArch()
 % written by Paul Mokotoff, prmoko@umich.edu
-% last updated: 19 sep 2024
+% last updated: 11 nov 2024
 %
 % Generate simple test cases to confirm that the propulsion architectures
 % are being created properly. Assume all tests are for turboprop
@@ -57,6 +57,9 @@ EtaProp = 0.80;
 
 % store the propeller efficiency
 TestIn.Specs.Power.Eta.Propeller = EtaProp;
+
+% store the engine fan efficiency
+TestIn.Specs.Propulsion.Engine.EtaPoly.Fan = 1;
 
 
 %% CASE 1A: CONVENTIONAL, 2 ENGINES %%

--- a/TestFAST.m
+++ b/TestFAST.m
@@ -2,7 +2,8 @@ function [] = TestFAST()
 %
 % [] = TestFAST()
 % written by Vaibhav Rau, vaibhav.rau@warriorlife.net
-% last updated: 13 sep 2024
+% modified by Paul Mokotoff, prmoko@umich.edu
+% last updated: 11 nov 2024
 %
 % Driver file for all FAST test cases.
 %
@@ -43,5 +44,13 @@ UnitConversionPkg.TestConvMass();
 UnitConversionPkg.TestConvTemp();
 UnitConversionPkg.TestConvTSFC();
 UnitConversionPkg.TestConvVel();
+
+
+%% TESTS COMPLETED %%
+%%%%%%%%%%%%%%%%%%%%%
+
+% print a notice
+fprintf(1, "\nAll FAST tests completed! Check above to see if any have failed.\n");
+
 
 end


### PR DESCRIPTION
TestCreatePropArch was failing because an engine fan efficiency was no longer implicitly assumed in the code. It must be explicitly provided by the user.