### PR TITLE
Constraint Diagram Updates for E9X Case Study

### DIFF
--- a/+AerodynamicsPkg/TrimDrag.m
+++ b/+AerodynamicsPkg/TrimDrag.m
@@ -2,7 +2,7 @@ function [dCD0] = TrimDrag(Aircraft)
 %
 % [dCD0] = TrimDrag(Aircraft)
 % written by Paul Mokotoff, prmoko@umich.edu
-% last updated: 08 jan 2026
+% last updated: 22 jul 2026
 %
 % estimate the trim drag from any failed engines.
 %
@@ -38,18 +38,24 @@ if (~any(Dwm))
     
     % return an array of zeros
     dCD0 = zeros(npnt, 1);
-
+    
     % exit the program
     return
     
 end
+
+% get the component
+icomp = Aircraft.Mission.History.SI.Power.Windmill(SegBeg);
+
+% get the number of sources
+nsrc = length(Aircraft.Specs.Propulsion.PropArch.SrcType);
 
 
 %% PRE-PROCESSING %%
 %%%%%%%%%%%%%%%%%%%%
 
 % get the SLS thrust
-Tsls = Aircraft.Specs.Propulsion.Engine.DesignThrust;
+Tsls = Aircraft.Specs.Propulsion.SLSThrust(icomp - nsrc);
 
 % get the moment arm between the fuselage and most outboard engine
 Arm = Aircraft.Specs.Aero.Fuse.DistToEng;

--- a/+AerodynamicsPkg/WindmillDrag.m
+++ b/+AerodynamicsPkg/WindmillDrag.m
@@ -2,7 +2,7 @@ function [Aircraft] = WindmillDrag(Aircraft)
 %
 % [Aircraft] = WindmillDrag(Aircraft)
 % written by Paul Mokotoff, prmoko@umich.edu
-% last updated: 05 jan 2026
+% last updated: 22 jul 2026
 %
 % estimate the windmilling drag from any failed engines.
 %
@@ -98,6 +98,9 @@ DelCD = DeltaCD(Tspec, Mach);
 % if there are any NaNs, convert them to zeros
 ThrCD(isnan(ThrCD)) = 0;
 DelCD(isnan(DelCD)) = 0;
+
+% if there are any theoretical drag coefficients less than 0, convert them to zero
+ThrCD(ThrCD <= 0) = 0;
 
 % compute the adjusted drag coefficient
 TotCD = ThrCD - DelCD;

--- a/+ConstraintDiagramPkg/+ConstraintSpecsPkg/ElysianE9X.m
+++ b/+ConstraintDiagramPkg/+ConstraintSpecsPkg/ElysianE9X.m
@@ -2,7 +2,7 @@ function [] = ElysianE9X()
 %
 % [] = ElysianE9X()
 % written by Paul Mokotoff, prmoko@umich.edu
-% last updated: 11 jul 2026
+% last updated: 13 jul 2026
 %
 % create a constraint diagram for a battery electric aircraft
 % representative of the Elysian E9X.
@@ -137,6 +137,10 @@ Aircraft.Specs.Power.P_W.SLS = 1/(0.0666*1000/9.81); % approx. 0.1473;
 % number of engines [2024 paper]
 Aircraft.Specs.Propulsion.NumEngines = 8;
 
+% lapse rate exponent correction factor for cruise/diversion/etc.
+Aircraft.Specs.Propulsion.LapseRate.Crs = 0.10;
+Aircraft.Specs.Propulsion.LapseRate.Div = 0.28;
+
 
 %% RUN THE CONSTRAINT ANALYSIS %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -147,32 +151,6 @@ Aircraft.Settings.ConstraintType = 2;
 
 % create a constraint diagram
 ConstraintDiagramPkg.ConstraintDiagram(Aircraft);
-
-% add the existing sizing point
-hold on
-scatter(Aircraft.Specs.Aero.W_S.SLS * 9.81 / 1000, 1 / (Aircraft.Specs.Power.P_W.SLS / 9.81 * 1000), 48, "o", "MarkerEdgeColor", [0, 0.251, 0.478], "MarkerFaceColor", [0, 0.251, 0.478]);
-
-% format the axis sizes
-xlim([0, 8]);
-ylim([0, 0.2]);
-axis square
-
-% turn on gridlines
-grid on
-
-% get the axis object
-A = gca;
-
-% set the grid to be semi-transparent and move it to the top
-A.GridAlpha = 0.5;
-A.Layer = "top";
-
-% add minor gridlines
-A.XMinorGrid = "on";
-A.YMinorGrid = "on";
-
-% increase font size
-set(gca, "FontSize", 28);
 
 
 end

--- a/+ConstraintDiagramPkg/+ConstraintSpecsPkg/ElysianE9X.m
+++ b/+ConstraintDiagramPkg/+ConstraintSpecsPkg/ElysianE9X.m
@@ -2,10 +2,21 @@ function [] = ElysianE9X()
 %
 % [] = ElysianE9X()
 % written by Paul Mokotoff, prmoko@umich.edu
-% last updated: 13 jul 2026
+% last updated: 22 jul 2026
 %
 % create a constraint diagram for a battery electric aircraft
 % representative of the Elysian E9X.
+%
+% data was extracted from the following papers, published in 2024 and 2025:
+%     1) de Vries, R., Wolleswinkel, R. E., Hoogreef, M., & Vos, R. (2024).
+%        A new perspective on battery-electric aviation, part II:
+%        Conceptual design of a 90-seater. In AIAA Scitech 2024 Forum 
+%        (p. 1490). https://doi.org/10.2514/6.2024-1490
+%
+%     2) de Vries, R., Wolleswinkel, R. E., Exalto, J., van den Berg, P.,
+%        Vos, R., & Hoogreef, M. (2025). Conceptual Redesign of a 90-Seater
+%        Battery-Electric Aircraft. In AIAA AVIATION FORUM AND ASCEND 2025
+%        (p. 3153). https://doi.org/10.2514/6.2025-3153
 %
 % INPUTS:
 %     none

--- a/+ConstraintDiagramPkg/+ConstraintSpecsPkg/ElysianE9X.m
+++ b/+ConstraintDiagramPkg/+ConstraintSpecsPkg/ElysianE9X.m
@@ -2,7 +2,7 @@ function [] = ElysianE9X()
 %
 % [] = ElysianE9X()
 % written by Paul Mokotoff, prmoko@umich.edu
-% last updated: 30 mar 2026
+% last updated: 11 jul 2026
 %
 % create a constraint diagram for a battery electric aircraft
 % representative of the Elysian E9X.
@@ -141,8 +141,9 @@ Aircraft.Specs.Propulsion.NumEngines = 8;
 %% RUN THE CONSTRAINT ANALYSIS %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% determine which constraints to use (0 = 14 CFR 25; 1 = novel)
-Aircraft.Settings.ConstraintType = 0;
+% determine which constraints to use (0 = 14 CFR 25; 1 = novel; 2 = Steiner
+% et al. [extrapolate exiting reg's for >4 engine aircraft])
+Aircraft.Settings.ConstraintType = 2;
 
 % create a constraint diagram
 ConstraintDiagramPkg.ConstraintDiagram(Aircraft);

--- a/+ConstraintDiagramPkg/+ConstraintSpecsPkg/SUSAN.m
+++ b/+ConstraintDiagramPkg/+ConstraintSpecsPkg/SUSAN.m
@@ -2,7 +2,7 @@ function [] = SUSAN()
 %
 % [] = SUSAN()
 % written by Paul Mokotoff, prmoko@umich.edu
-% last updated: 25 sep 2025
+% last updated: 13 jul 2026
 %
 % create a constraint diagram for NASA's SUSAN aircraft.
 %
@@ -28,7 +28,7 @@ clc, close all
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 % aircraft class
-Aircraft.Specs.TLAR.Class = "Turbofan";
+Aircraft.Specs.TLAR.Class = "Turboprop";
 
 % CFR regulations to certify
 Aircraft.Specs.TLAR.CFRPart = 25;
@@ -41,19 +41,21 @@ Aircraft.Specs.TLAR.CFRPart = 25;
 %                            %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% altitudes
-Aircraft.Specs.Performance.Alts.Crs = UnitConversionPkg.ConvLength(40000, "ft", "m");
-Aircraft.Specs.Performance.Alts.Srv = UnitConversionPkg.ConvLength(42000, "ft", "m");
+% altitudes [cruise from economy mission outlined in 2024 paper; service
+% ceiling estimated]
+Aircraft.Specs.Performance.Alts.Crs = UnitConversionPkg.ConvLength(37000, "ft", "m");
+Aircraft.Specs.Performance.Alts.Srv = UnitConversionPkg.ConvLength(40000, "ft", "m");
 
-% stall speed
+% stall speed [based on wing loading from 2024 paper]
 Aircraft.Specs.Performance.Vels.Stl = sqrt(2 * 634 * 9.81 / 2 / 1.225);
 
-% cruise mach number
+% cruise mach number [2024 paper, Tab. 5]
 Aircraft.Specs.Performance.Vels.Crs = 0.775;
 
-% runway lengths and obstacle clearances
-Aircraft.Specs.Performance.TOFL    = 2750;
-Aircraft.Specs.Performance.LFL     = 2750;
+% runway lengths and obstacle clearances [Boeing 737-800 MAX airport
+% planning manual]
+Aircraft.Specs.Performance.TOFL    = 2040;
+Aircraft.Specs.Performance.LFL     = 1700;
 Aircraft.Specs.Performance.ObstLen = UnitConversionPkg.ConvLength(1000, "ft", "m");
 
 % multiplicative factors for OEI conditions
@@ -61,13 +63,13 @@ Aircraft.Specs.Performance.TempInc = 1.25;
 Aircraft.Specs.Performance.MaxCont = 1 / 0.94;
 
 % design specific excess power loss
-Aircraft.Specs.Performance.PsLoss = 0.7689; % mean for twin-engine aircraft
+Aircraft.Specs.Performance.PsLoss = 0.9171; % mean for twin-engine aircraft
 
-% landing weight as a fraction of MTOW (computed from baseline)
+% landing weight as a fraction of MTOW (computed from FAST simulations)
 Aircraft.Specs.Performance.Wland_MTOW = 0.8411;
 
 % requirement type (0 = Roskam; 1 = Mattingly, 2 = de Vries et al.)
-Aircraft.Specs.TLAR.ReqType = 0;
+Aircraft.Specs.TLAR.ReqType = 2;
 
 % constraints to use
 Aircraft.Specs.Performance.ConstraintFuns = ["Jet25_111"; "Jet25_119"; "Jet25_121a"; "Jet25_121b"; "Jet25_121c"; "Jet25_121d"; "JetCrs"; "JetLFL"; "JetTOFL"];
@@ -83,18 +85,19 @@ Aircraft.Specs.Performance.ConstraintLabs = ["25.111"; "25.119"; "25.121a"; "25.
 %                            %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% wing loading
+% wing loading [2024 paper]
 Aircraft.Specs.Aero.W_S.SLS = 634;
 
-% wing properties
-Aircraft.Specs.Aero.AR = 11.22091;
+% wing properties [2024 paper]
+Aircraft.Specs.Aero.AR = 9.44;
 
-% lift coefficients (from Chau & Duensing and FINCH)
-Aircraft.Specs.Aero.CL.Crs = 0.61;
-Aircraft.Specs.Aero.CL.Tko = 2.0;
-Aircraft.Specs.Aero.CL.Lnd = 3.5;
+% lift coefficients [cruise lift coefficient from 2024 paper, others are
+% estimated based DEP tech. improvements]
+Aircraft.Specs.Aero.CL.Crs = 1.0; % given as 0.61 in 2024 paper, but need maximum CL for the constraint diagram
+Aircraft.Specs.Aero.CL.Tko = 2.5;
+Aircraft.Specs.Aero.CL.Lnd = 3.0;
 
-% parasite drag coefficients (computed)
+% parasite drag coefficients (computed from Raymer)
 Aircraft.Specs.Aero.CD0.Crs = 0.0176;
 Aircraft.Specs.Aero.CD0.Tko = 0.0626; % cruise CD0 + 0.045
 Aircraft.Specs.Aero.CD0.Lnd = 0.1076; % cruise CD0 + 0.090
@@ -112,7 +115,7 @@ Aircraft.Specs.Aero.e.Lnd = 0.7330; % 90% of cruise e
 %                            %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% MTOW
+% MTOW [2024 paper]
 Aircraft.Specs.Weight.MTOW = UnitConversionPkg.ConvMass(190890, "lbm", "kg");
 
 % ----------------------------------------------------------
@@ -124,11 +127,18 @@ Aircraft.Specs.Weight.MTOW = UnitConversionPkg.ConvMass(190890, "lbm", "kg");
 %                            %
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-% thrust-weight ratio
+% thrust-weight ratio [2024 paper]
 Aircraft.Specs.Propulsion.T_W.SLS = 0.298;
 
-% number of engines
+% number of engines [for appropriate FARs]
 Aircraft.Specs.Propulsion.NumEngines = 2;
+
+% lapse rate [estimated]
+Aircraft.Specs.Propulsion.LapseRate.Crs = 0.35;
+
+% alternatively, a power-weight ratio [assumed takoeff airspeed as the
+% "characteristic speed" to avoid singularities]
+Aircraft.Specs.Power.P_W.SLS = (Aircraft.Specs.Propulsion.T_W.SLS * 1.21 * Aircraft.Specs.Performance.Vels.Stl) * 9.81 / 1000;
 
 
 %% RUN THE CONSTRAINT ANALYSIS %%
@@ -142,6 +152,6 @@ ConstraintDiagramPkg.ConstraintDiagram(Aircraft);
 
 % add the existing sizing point
 hold on
-scatter(Aircraft.Specs.Aero.W_S.SLS, Aircraft.Specs.Propulsion.T_W.SLS, 48, "o", "MarkerEdgeColor", "red", "MarkerFaceColor", "red");
+scatter(Aircraft.Specs.Aero.W_S.SLS * 9.81 / 1000, 1 / (Aircraft.Specs.Power.P_W.SLS / 9.81 * 1000), 48, "o", "MarkerEdgeColor", "red", "MarkerFaceColor", "red");
 
 end

--- a/+ConstraintDiagramPkg/+ConstraintSpecsPkg/SUSAN.m
+++ b/+ConstraintDiagramPkg/+ConstraintSpecsPkg/SUSAN.m
@@ -2,7 +2,7 @@ function [] = SUSAN()
 %
 % [] = SUSAN()
 % written by Paul Mokotoff, prmoko@umich.edu
-% last updated: 13 jul 2026
+% last updated: 22 jul 2026
 %
 % create a constraint diagram for NASA's SUSAN aircraft.
 %
@@ -63,7 +63,10 @@ Aircraft.Specs.Performance.TempInc = 1.25;
 Aircraft.Specs.Performance.MaxCont = 1 / 0.94;
 
 % design specific excess power loss
-Aircraft.Specs.Performance.PsLoss = 0.9171; % mean for twin-engine aircraft
+% 0.9171 - mean SEP loss for twin-engine aircraft
+% 0.0720 - lose a single distributed propulsor (most outboard)
+% 0.3426 - lose the aft turbofan engine
+Aircraft.Specs.Performance.PsLoss = 0.3426;
 
 % landing weight as a fraction of MTOW (computed from FAST simulations)
 Aircraft.Specs.Performance.Wland_MTOW = 0.8411;

--- a/+ConstraintDiagramPkg/+ConstraintSpecsPkg/SUSAN.m
+++ b/+ConstraintDiagramPkg/+ConstraintSpecsPkg/SUSAN.m
@@ -4,7 +4,12 @@ function [] = SUSAN()
 % written by Paul Mokotoff, prmoko@umich.edu
 % last updated: 22 jul 2026
 %
-% create a constraint diagram for NASA's SUSAN aircraft.
+% create a constraint diagram for NASA's SUSAN aircraft. information was
+% extracted from the following paper:
+%
+% Chau, T., & Duensing, J. (2024). Conceptual Design of the Hybrid-Electric
+% Subsonic Single Aft Engine (SUSAN) Electrofan Transport Aircraft. In AIAA
+% SciTech 2024 Forum (p. 1326). https://doi.org/10.2514/6.2024-1326
 %
 % INPUTS:
 %     none

--- a/+ConstraintDiagramPkg/Jet25_111.m
+++ b/+ConstraintDiagramPkg/Jet25_111.m
@@ -2,7 +2,7 @@ function [FAR] = Jet25_111(W_S, T_W, Aircraft)
 %
 % [FAR] = Jet25_111(W_S, T_W, Aircraft)
 % written by Paul Mokotoff, prmoko@umich.edu
-% last updated: 30 mar 2026
+% last updated: 11 jul 2026
 %
 % derive the constraints for takeoff climb with one engine inoperative.
 %
@@ -71,6 +71,11 @@ elseif (Type == 1)
     
     % compute the climb gradient from a sigmoid curve
     G = ConstraintDiagramPkg.Sigmoid(Aircraft, 0.5026, -42.54, 0.7925, 1.198);
+    
+elseif (Type == 2)
+    
+    % extrapolate for any aircraft with more than 4 engines
+    G = 0.005 + 0.003 * NumEng;
     
 else
     

--- a/+ConstraintDiagramPkg/Jet25_119.m
+++ b/+ConstraintDiagramPkg/Jet25_119.m
@@ -2,7 +2,7 @@ function [FAR] = Jet25_119(W_S, T_W, Aircraft)
 %
 % [FAR] = Jet25_119(W_S, T_W, Aircraft)
 % written by Paul Mokotoff, prmoko@umich.edu
-% last updated: 04 dec 2025
+% last updated: 11 jul 2026
 %
 % derive the constraints for a balked landing climb with all engines
 % operative.
@@ -60,6 +60,12 @@ elseif (Type == 1)
     
     % compute the climb gradient from a sigmoid curve
     G = ConstraintDiagramPkg.Sigmoid(Aircraft, 0, 0, 0, 3.2);
+    
+elseif (Type == 2)
+    
+    % extrapolate for any aircraft with more than 4 engines, but it will
+    % always remain the same here
+    G = 0.032;
     
 else
     

--- a/+ConstraintDiagramPkg/Jet25_121a.m
+++ b/+ConstraintDiagramPkg/Jet25_121a.m
@@ -2,7 +2,7 @@ function [FAR] = Jet25_121a(W_S, T_W, Aircraft)
 %
 % [FAR] = Jet25_121a(W_S, T_W, Aircraft)
 % written by Paul Mokotoff, prmoko@umich.edu
-% last updated: 30 mar 2026
+% last updated: 11 jul 2026
 %
 % derive the constraints for the transition segment climb.
 %
@@ -71,6 +71,13 @@ elseif (Type == 1)
     
     % compute the climb gradient from a sigmoid curve
     G = ConstraintDiagramPkg.Sigmoid(Aircraft, 0.4999, -151.22, 0.7855, 0.001);
+    
+elseif (Type == 2)
+    
+    % extrapolate for any aircraft with more than 4 engines (only applies
+    % for >4 engines, but taking the maximum in case an aircraft with <=4
+    % engines is being designed
+    G = max(0, -0.007 + 0.003 * NumEng);
     
 else
     

--- a/+ConstraintDiagramPkg/Jet25_121b.m
+++ b/+ConstraintDiagramPkg/Jet25_121b.m
@@ -2,7 +2,7 @@ function [FAR] = Jet25_121b(W_S, T_W, Aircraft)
 %
 % [FAR] = Jet25_121b(W_S, T_W, Aircraft)
 % written by Paul Mokotoff, prmoko@umich.edu
-% last updated: 30 mar 2026
+% last updated: 11 jul 2026
 %
 % derive the constraints for the second segment climb.
 %
@@ -71,6 +71,11 @@ elseif (Type == 1)
     
     % compute the climb gradient from a sigmoid curve
     G = ConstraintDiagramPkg.Sigmoid(Aircraft, 0.6024, -42.00, 0.7829, 2.398);
+    
+elseif (Type == 2)
+    
+    % extrapolate for any aircraft with more than 4 engines
+    G = 0.018 + 0.003 * NumEng;
     
 else
     

--- a/+ConstraintDiagramPkg/Jet25_121c.m
+++ b/+ConstraintDiagramPkg/Jet25_121c.m
@@ -2,7 +2,7 @@ function [FAR] = Jet25_121c(W_S, T_W, Aircraft)
 %
 % [FAR] = Jet25_121c(W_S, T_W, Aircraft)
 % written by Paul Mokotoff, prmoko@umich.edu
-% last updated: 30 mar 2026
+% last updated: 11 jul 2026
 %
 % derive the constraints for the enroute climb.
 %
@@ -72,6 +72,11 @@ elseif (Type == 1)
     
     % compute the climb gradient from a sigmoid curve
     G = ConstraintDiagramPkg.Sigmoid(Aircraft, 0.5026, -42.54, 0.7925, 1.198);
+    
+elseif (Type == 2)
+    
+    % extrapolate for any aircraft with more than 4 engines
+    G = 0.005 + 0.003 * NumEng;
     
 else
     

--- a/+ConstraintDiagramPkg/Jet25_121d.m
+++ b/+ConstraintDiagramPkg/Jet25_121d.m
@@ -2,7 +2,7 @@ function [FAR] = Jet25_121d(W_S, T_W, Aircraft)
 %
 % [FAR] = Jet25_121d(W_S, T_W, Aircraft)
 % written by Paul Mokotoff, prmoko@umich.edu
-% last updated: 30 mar 2026
+% last updated: 11 jul 2026
 %
 % derive the constraints for landing climb with one engine inoperative.
 %
@@ -72,6 +72,11 @@ elseif (Type == 1)
     
     % compute the climb gradient from a sigmoid curve
     G = ConstraintDiagramPkg.Sigmoid(Aircraft, 0.6025, -41.75, 0.7830, 2.098);
+    
+elseif (Type == 2)
+    
+    % extrapolate for any aircraft with more than 4 engines
+    G = 0.015 + 0.003 * NumEng;
     
 else
     

--- a/+ConstraintDiagramPkg/JetCeil.m
+++ b/+ConstraintDiagramPkg/JetCeil.m
@@ -2,7 +2,7 @@ function [FAR] = JetCeil(W_S, T_W, Aircraft)
 %
 % [FAR] = JetCeil(W_S, T_W, Aircraft)
 % written by Paul Mokotoff, prmoko@umich.edu
-% last updated: 16 sep 2025
+% last updated: 13 jul 2026
 %
 % derive the constraints for service ceiling.
 %
@@ -37,6 +37,9 @@ zserv   = Aircraft.Specs.Performance.Alts.Srv; % keep in SI units for ComputeFlt
 ReqType = Aircraft.Specs.TLAR.ReqType;
 CrsMach = Aircraft.Specs.Performance.Vels.Crs;
 
+% get the lapse rate
+LapseRate = Aircraft.Specs.Propulsion.LapseRate.Ceil;
+
 
 %% EVALUATE THE CONSTRAINT %%
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -55,7 +58,7 @@ G = 0.001;
 if (ReqType == 0)
     
     % use the metabook's equation
-    FAR = (2 * sqrt(CD0 / pi / e / AR) + G) / RhoRatio ^ 0.6 - T_W;
+    FAR = (2 * sqrt(CD0 / pi / e / AR) + G) / RhoRatio ^ LapseRate - T_W;
     
 elseif (ReqType == 1)
 
@@ -83,7 +86,7 @@ elseif (ReqType == 1)
     end
     
     % use Mattingly's equation for service ceiling
-    FAR = 1 ./ RhoRatio ^ 0.6 .* (q .* CD0 ./ W_S + W_S ./ q ./ (pi * AR * e) + G) - T_W;
+    FAR = 1 ./ RhoRatio ^ LapseRate .* (q .* CD0 ./ W_S + W_S ./ q ./ (pi * AR * e) + G) - T_W;
     
 else
     

--- a/+ConstraintDiagramPkg/JetCrs.m
+++ b/+ConstraintDiagramPkg/JetCrs.m
@@ -2,7 +2,7 @@ function [FAR] = JetCrs(W_S, T_W, Aircraft)
 %
 % [FAR] = JetCrs(W_S, T_W, Aircraft)
 % written by Paul Mokotoff, prmoko@umich.edu
-% last updated: 04 sep 2025
+% last updated: 13 jul 2026
 %
 % derive the constraints for cruise performance.
 %
@@ -35,6 +35,9 @@ AR   = Aircraft.Specs.Aero.AR;
 e    = Aircraft.Specs.Aero.e.Crs;
 Mcrs = Aircraft.Specs.Performance.Vels.Crs;
 zcrs = Aircraft.Specs.Performance.Alts.Crs; % keep in SI units for ComputeFltCon
+
+% get the lapse rate
+LapseRate = Aircraft.Specs.Propulsion.LapseRate.Crs;
 
 % get the requirement type
 ReqType = Aircraft.Specs.TLAR.ReqType;
@@ -84,7 +87,7 @@ if (ReqType == 0 || ReqType == 1) % Roskam and Mattingly's equations match
     else
         
         % requirement is thrust-based, account for engine lapsing
-        FAR = (q .* CD0 ./ W_S + W_S ./ (q .* pi .* AR .* e)) ./ RhoRatio ^ 0.6 - T_W;
+        FAR = (q .* CD0 ./ W_S + W_S ./ (q .* pi .* AR .* e)) ./ RhoRatio ^ LapseRate - T_W;
     
     end
     
@@ -94,7 +97,7 @@ elseif (ReqType == 2)
     CL = W_S ./ q;
     
     % use a different equation
-    FAR = q ./ W_S .* (CD0 + CL .^ 2 ./ (pi * AR * e)) ./ RhoRatio ^ 0.1 - T_W;
+    FAR = q ./ W_S .* (CD0 + CL .^ 2 ./ (pi * AR * e)) ./ RhoRatio ^ LapseRate - T_W;
     
 else
     

--- a/+ConstraintDiagramPkg/JetDiv.m
+++ b/+ConstraintDiagramPkg/JetDiv.m
@@ -2,7 +2,7 @@ function [FAR] = JetDiv(W_S, T_W, Aircraft)
 %
 % [FAR] = JetDiv(W_S, T_W, Aircraft)
 % written by Paul Mokotoff, prmoko@umich.edu
-% last updated: 04 dec 2025
+% last updated: 13 jul 2026
 %
 % derive the constraints for diversion (cruise) performance.
 %
@@ -35,6 +35,9 @@ AR   = Aircraft.Specs.Aero.AR;
 e    = Aircraft.Specs.Aero.e.Crs;
 Mcrs = Aircraft.Specs.Performance.Vels.Div;
 zcrs = Aircraft.Specs.Performance.Alts.Div; % keep in SI units for ComputeFltCon
+
+% get the lapse rate
+LapseRate = Aircraft.Specs.Propulsion.LapseRate.Div;
 
 % get the requirement type
 ReqType = Aircraft.Specs.TLAR.ReqType;
@@ -84,7 +87,7 @@ if (ReqType == 0 || ReqType == 1) % Roskam and Mattingly's equations match
     else
         
         % requirement is thrust-based, account for engine lapsing
-        FAR = (q .* CD0 ./ W_S + W_S ./ (q .* pi .* AR .* e)) ./ RhoRatio ^ 0.6 - T_W;
+        FAR = (q .* CD0 ./ W_S + W_S ./ (q .* pi .* AR .* e)) ./ RhoRatio ^ LapseRate - T_W;
     
     end
     
@@ -94,7 +97,7 @@ elseif (ReqType == 2)
     CL = W_S ./ q;
     
     % use a different equation
-    FAR = q ./ W_S .* (CD0 + CL .^ 2 ./ (pi * AR * e)) ./ RhoRatio ^ 0.2 - T_W;
+    FAR = q ./ W_S .* (CD0 + CL .^ 2 ./ (pi * AR * e)) ./ RhoRatio ^ LapseRate - T_W;
     
 else
     

--- a/+ConstraintDiagramPkg/OEIMultiplier.m
+++ b/+ConstraintDiagramPkg/OEIMultiplier.m
@@ -2,7 +2,7 @@ function [k] = OEIMultiplier(Aircraft)
 %
 % [k] = OEIMultiplier(Aircraft)
 % written by Paul Mokotoff, prmoko@umich.edu
-% last updated: 04 mar 2026
+% last updated: 11 jul 2026
 %
 % return the appropriate multiplier for engine inoperative conditons,
 % either based on a discrete number of engines installed or a percent
@@ -21,7 +21,7 @@ function [k] = OEIMultiplier(Aircraft)
 Type = Aircraft.Settings.ConstraintType;
 
 % check the multiplier type
-if (Type == 0)
+if ((Type == 0) || (Type == 2))
     
     % get the number of engines
     Neng = Aircraft.Specs.Propulsion.NumEngines;

--- a/+ConstraintDiagramPkg/README.m
+++ b/+ConstraintDiagramPkg/README.m
@@ -26,7 +26,7 @@ function [] = README()
 %     Michael Tsai
 %     Vaibhav Rau
 % 
-% README last updated: 06 Oct 2025
+% README last updated: 22 July 2026
 % 
 % -------------------------------------------------------------------------
 %
@@ -176,11 +176,19 @@ function [] = README()
 %     MTOW - maximum takeoff weight
 %
 % Propulsion
-%     T_W.SLS    - thrust-to-weight ratio at sea-level, used for turbofan
-%                  aircraft
+%     T_W.SLS        - thrust-to-weight ratio at sea-level, used for
+%                      turbofan aircraft
 %
-%     NumEngines - number of engines installed (used for 14 CFR 25 climb
-%                  gradients)
+%     NumEngines     - number of engines installed (used for 14 CFR 25
+%                      climb gradients)
+%
+%     LapseRate.Crs  - engine lapse rate during cruise (or at cruise
+%                      altitude)
+%
+%     LapseRate.Div  - engine lapse rate during a diversion (or at the
+%                      corresponding altitude)
+%
+%     LapseRate.Ceil - engine lapse rate at the service ceiling
 %
 % Power
 %     P_W.SLS - power-to-weight ratio at sea-level, used for turboprop or
@@ -195,6 +203,8 @@ function [] = README()
 %                      a) 0 - climb gradients from 14 CFR 25
 %                      b) 1 - climb gradients as a function of the specific
 %                             excess power loss
+%                      c) 2 - climb gradients as a function of the number
+%                             of propulsors installed on the aircraft
 %
 % -------------------------------------------------------------------------
 %


### PR DESCRIPTION
Updates to the constraint diagram generation process were made:
- Engine lapse rates can now be defined parametrically
- An additional requirement formulation was included, requiring steeper climb gradients for configurations with >4 propulsors (see https://doi.org/10.1007/s13272-013-0096-6)
- Trim drag can now be easily evaluated for heterogeneously-sized propulsion systems

Additional changes were made to the existing Constraint Diagram Specification files, detailing where information was extracted from.